### PR TITLE
Add missing import of lodash.map

### DIFF
--- a/edit.js
+++ b/edit.js
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-const { filter, pick, get } = lodash;
+const { filter, pick, get, map } = lodash;
 
 /**
  * WordPress dependencies


### PR DESCRIPTION
This is used here

https://github.com/anna-werner/gutenberg-slider/blob/36845c232875bcfe6cac11b0a35d279ddcd1896f/edit.js#L96

Note, that i didn't rebuild the dist files.